### PR TITLE
Fix XPath attribute set generation bug

### DIFF
--- a/Robula/robula_plus.py
+++ b/Robula/robula_plus.py
@@ -237,11 +237,11 @@ class RobulaPlus(object):
             attributePowerSet = self.generatePowerSet(attributes)
 
             # remove sets with cardinality < 2
-            attributePowerSet = filter(lambda x: len(x) >= 2, attributePowerSet)
+            attributePowerSet = [s for s in attributePowerSet if len(s) >= 2]
 
             # sort elements inside each powerset
-            for attributeSet in attributePowerSet:
-                attributeSet = sorted(attributeSet, key=cmp_to_key(self.elementCompareFunction))
+            for i, attributeSet in enumerate(attributePowerSet):
+                attributePowerSet[i] = sorted(attributeSet, key=cmp_to_key(self.elementCompareFunction))
 
             # sort attributePowerSet
             attributePowerSet = sorted(attributePowerSet, key=cmp_to_key(self.compareListElementAttributes))
@@ -255,7 +255,7 @@ class RobulaPlus(object):
                 value = attributeSet[0]['value']
                 predicate = f"[@{key}='{value}'"
 
-                for i in range(0, len(attributeSet)):
+                for i in range(1, len(attributeSet)):
                     key = attributeSet[i]['name']
                     value = attributeSet[i]['value']
                     predicate += f" and @{key}='{value}'"

--- a/Robula/xpath.py
+++ b/Robula/xpath.py
@@ -26,8 +26,12 @@ class XPath(object):
 
     def headHasPositionPredicate(self) -> bool:
         splitXPath = self.value.split('/')
-        regExp = re.compile('[\[0-9\]]')
-        return 'position()' in splitXPath[2] or 'last()' in splitXPath[2] or bool(re.match(regExp, splitXPath[2]))
+        regExp = re.compile(r'\[\d+\]')
+        return (
+            'position()' in splitXPath[2]
+            or 'last()' in splitXPath[2]
+            or bool(regExp.search(splitXPath[2]))
+        )
 
     def headHasTextPredicate(self) -> bool:
         return 'text()' in self.value.split('/')[2]

--- a/tests/test_robula.py
+++ b/tests/test_robula.py
@@ -1,0 +1,23 @@
+import unittest
+from Robula.robula_plus import RobulaPlus
+from Robula.xpath import XPath
+
+from lxml.etree import HTML
+
+class TestRobula(unittest.TestCase):
+    def test_transf_add_attribute_set(self):
+        rp = RobulaPlus()
+        doc = rp.makeDocument('<html><body><div id="id1" class="foo"></div></body></html>')
+        el = doc.xpath('//div')[0]
+        results = rp.transfAddAttributeSet(XPath('//*'), el)
+        values = [x.getValue() for x in results]
+        self.assertIn("//*[@id='id1' and @class='foo']", values)
+
+    def test_head_has_position_predicate(self):
+        self.assertTrue(XPath('//div[2]').headHasPositionPredicate())
+        self.assertTrue(XPath('//*[last()]').headHasPositionPredicate())
+        self.assertTrue(XPath('//*[position()=1]').headHasPositionPredicate())
+        self.assertFalse(XPath('//*[@id="x"]').headHasPositionPredicate())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- correct generation of attribute set predicates
- improve detection of position predicates in XPath
- add regression tests for attribute set generation and position predicate detection

## Testing
- `python -m unittest tests.test_robula -v`

------
https://chatgpt.com/codex/tasks/task_e_6840539e76ac8322bb217dc827cfe49a